### PR TITLE
Update __init__.py

### DIFF
--- a/jesse/__init__.py
+++ b/jesse/__init__.py
@@ -36,6 +36,9 @@ warnings.simplefilter(action='ignore', category=FutureWarning)
 # get the jesse directory
 JESSE_DIR = pkg_resources.resource_filename(__name__, '')
 
+# On Windows operating systems, it is necessary to explicitly declare support for the .js MIME type; otherwise, JavaScript files may fail to load, resulting in a blank (white) page in the browser.
+import mimetypes
+mimetypes.add_type('application/javascript', '.js')
 
 # load homepage
 @fastapi_app.get("/")


### PR DESCRIPTION
On Windows, the MIME type for .js files may not be correctly recognized by default in some server environments. To prevent JavaScript loading issues (which may lead to a blank page), you should manually add MIME type support as shown below:
import mimetypes
mimetypes.add_type('application/javascript', '.js')